### PR TITLE
Script to transfer the proxy ownership of all the contracts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,5 +36,5 @@ rand = { version = "0.8.5", features = ["std_rng", "getrandom"] }
 serde = { version = "1.0.92", features = ["derive"] }
 serde_json = "1.0.92"
 tai64 = "4.0.0"
-tokio = { version = "1.21.0", features = ["rt", "macros"] }
 test-utils = { path = "./test-utils" }
+tokio = { version = "1.21.0", features = ["rt", "macros"] }

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ include .env
 export $(shell sed 's/=.*//' .env)
 ############################# HELP MESSAGE #############################
 # Make sure the help command stays first, so that it's printed by default when `make` is called without arguments
-.PHONY: help tests build-and-test generate-types deploy add-asset pause unpause sanity-check transfer-owner
+.PHONY: help tests build-and-test generate-types deploy add-asset pause unpause sanity-check transfer-owner transfer-proxy-ownership
 help:
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
@@ -37,3 +37,6 @@ sanity-check: ## Run the sanity check script (usage: make sanity-check NETWORK=<
 
 transfer-owner: ## Transfer ownership of the protocol (usage: make transfer-owner NETWORK=<mainnet|testnet> ADDRESS=<new_owner_address>)
 	@cd deploy-scripts && NETWORK=$(NETWORK) SECRET=$(SECRET) cargo run transfer-owner $(ADDRESS)
+
+transfer-proxy-ownership: ## Transfer ownership of the proxy contracts (usage: make transfer-proxy-ownership NETWORK=<mainnet|testnet> ADDRESS=<new_owner_address>)
+	@cd deploy-scripts && NETWORK=$(NETWORK) SECRET=$(SECRET) cargo run transfer-proxy-ownership $(ADDRESS)

--- a/contracts/proxy-contract/Cargo.toml
+++ b/contracts/proxy-contract/Cargo.toml
@@ -7,9 +7,8 @@ license = "Apache-2.0"
 
 [dependencies]
 fuels = { workspace = true }
-tokio = { workspace = true }
 test-utils = { workspace = true }
-# Not the latest version because of indexer bug o.o 
+tokio = { workspace = true }
 
 [[test]]
 harness = true

--- a/deploy-scripts/Cargo.toml
+++ b/deploy-scripts/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
+csv = { workspace = true }
 dotenv = { workspace = true }
 fuels = { workspace = true }
 futures = { workspace = true }
@@ -13,10 +14,10 @@ hex = { workspace = true }
 pbr = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+tai64 = { workspace = true }
 test-utils = { workspace = true }
 tokio = { workspace = true }
-csv = { workspace = true }
-tai64 = { workspace = true }
+
 
 [lib]
 doctest = false

--- a/deploy-scripts/src/lib.rs
+++ b/deploy-scripts/src/lib.rs
@@ -4,4 +4,5 @@ pub mod deploy;
 pub mod pause;
 pub mod sanity_check;
 pub mod transfer_ownership;
+pub mod transfer_proxy_ownership;
 pub mod utils;

--- a/deploy-scripts/src/main.rs
+++ b/deploy-scripts/src/main.rs
@@ -4,6 +4,7 @@ use deploy_scripts::{
     pause::{pause_protocol, unpause_protocol},
     sanity_check::sanity_check,
     transfer_ownership::transfer_owner,
+    transfer_proxy_ownership::transfer_proxy_ownership,
 };
 
 #[tokio::main]
@@ -34,6 +35,13 @@ pub async fn main() {
                 return;
             }
             transfer_owner(&args[2]).await
+        },
+        "transfer-proxy-ownership" => {
+            if args.len() < 3 {
+                println!("Please specify the new owner address");
+                return;
+            }
+            transfer_proxy_ownership(&args[2]).await
         },
         _ => println!(
             "Invalid argument. Use 'deploy', 'add-asset <symbol>', 'pause', 'unpause', 'sanity-check', or 'transfer-owner <address>'"

--- a/deploy-scripts/src/transfer_proxy_ownership.rs
+++ b/deploy-scripts/src/transfer_proxy_ownership.rs
@@ -1,0 +1,128 @@
+use crate::utils::utils::{is_testnet, load_core_contracts, setup_wallet};
+use dotenv::dotenv;
+use fuels::types::Identity;
+use test_utils::interfaces::proxy::{proxy_abi, Proxy, State};
+
+pub async fn transfer_proxy_ownership(new_owner: &str) {
+    dotenv().ok();
+
+    let wallet = setup_wallet().await;
+    let address = wallet.address();
+    println!("🔑 Wallet address: {}", address);
+
+    let is_testnet = is_testnet(wallet.clone()).await;
+    let core_contracts = load_core_contracts(wallet.clone(), is_testnet);
+
+    println!(
+        "Are you sure you want to transfer ownership to {}? (y/n)",
+        new_owner
+    );
+    let mut input = String::new();
+    std::io::stdin()
+        .read_line(&mut input)
+        .expect("Failed to read line");
+    if input.trim().to_lowercase() != "y" {
+        println!("Operation cancelled.");
+        return;
+    }
+
+    // Convert string address to Identity
+    let new_owner_identity = Identity::Address(new_owner.parse().expect("Invalid address format"));
+    let proxy_owner_state = State::Initialized(new_owner_identity);
+
+    // Transfer ownership for all proxy contracts
+    let contracts_to_update = [
+        (
+            "Active Pool",
+            core_contracts.active_pool.contract.contract_id(),
+        ),
+        (
+            "Borrow Operations",
+            core_contracts.borrow_operations.contract.contract_id(),
+        ),
+        ("USDF Token", core_contracts.usdf.contract.contract_id()),
+        (
+            "Stability Pool",
+            core_contracts.stability_pool.contract.contract_id(),
+        ),
+        (
+            "Protocol Manager",
+            core_contracts.protocol_manager.contract.contract_id(),
+        ),
+        (
+            "FPT Staking",
+            core_contracts.fpt_staking.contract.contract_id(),
+        ),
+        (
+            "Coll Surplus Pool",
+            core_contracts.coll_surplus_pool.contract.contract_id(),
+        ),
+        (
+            "Sorted Troves",
+            core_contracts.sorted_troves.contract.contract_id(),
+        ),
+        (
+            "Default Pool",
+            core_contracts.default_pool.contract.contract_id(),
+        ),
+        ("FPT Token", core_contracts.fpt_token.contract.contract_id()),
+        (
+            "Community Issuance",
+            core_contracts.community_issuance.contract.contract_id(),
+        ),
+        (
+            "Vesting Contract",
+            core_contracts.vesting_contract.contract.contract_id(),
+        ),
+    ];
+
+    for (contract_name, contract_id) in contracts_to_update.iter() {
+        let proxy_contract = Proxy::new(*contract_id, wallet.clone());
+        if let Err(e) = proxy_abi::set_proxy_owner(&proxy_contract, proxy_owner_state.clone()).await
+        {
+            println!(
+                "❌ Failed to transfer {} proxy ownership: {:?}",
+                contract_name, e
+            );
+            std::process::exit(1);
+        }
+        println!(
+            "✅ {} proxy ownership transferred successfully",
+            contract_name
+        );
+    }
+
+    // Transfer ownership for each asset's contracts
+    for asset_contract in core_contracts.asset_contracts.iter() {
+        let asset_specific_contracts = [
+            ("Oracle", asset_contract.oracle.contract.contract_id()),
+            (
+                "Trove Manager",
+                asset_contract.trove_manager.contract.contract_id(),
+            ),
+        ];
+
+        println!(
+            "\nTransferring ownership for Asset: {}",
+            asset_contract.asset_id
+        );
+        for (contract_name, contract_id) in asset_specific_contracts.iter() {
+            let proxy_contract = Proxy::new(*contract_id, wallet.clone());
+            if let Err(e) =
+                proxy_abi::set_proxy_owner(&proxy_contract, proxy_owner_state.clone()).await
+            {
+                println!(
+                    "❌ Failed to transfer {} proxy ownership: {:?}",
+                    contract_name, e
+                );
+                std::process::exit(1);
+            }
+            println!(
+                "✅ {} proxy ownership transferred successfully",
+                contract_name
+            );
+        }
+    }
+
+    println!("\n🎉 Proxy ownership transfer completed for all contracts");
+}

--- a/deploy-scripts/src/transfer_proxy_ownership.rs
+++ b/deploy-scripts/src/transfer_proxy_ownership.rs
@@ -1,13 +1,13 @@
 use crate::utils::utils::{is_testnet, load_core_contracts, setup_wallet};
 use dotenv::dotenv;
-use fuels::types::Identity;
+use fuels::types::{Address, Identity};
 use test_utils::interfaces::proxy::{proxy_abi, Proxy, State};
 
 pub async fn transfer_proxy_ownership(new_owner: &str) {
     dotenv().ok();
 
     let wallet = setup_wallet().await;
-    let address = wallet.address();
+    let address: Address = wallet.address().into();
     println!("🔑 Wallet address: {}", address);
 
     let is_testnet = is_testnet(wallet.clone()).await;


### PR DESCRIPTION
Add script to transfer proxy ownership across all protocol contracts

This PR introduces a new script that facilitates the transfer of proxy ownership for all protocol contracts to a new owner address. The script:

- Takes a new owner address as input
- Requires user confirmation before proceeding
- Transfers ownership for all core protocol contracts
- Handles asset-specific contracts (Oracle and Trove Manager) for each configured asset
- Exits with an error if any transfer fails

This script will be useful for administrative operations and protocol upgrades where proxy ownership needs to be transferred to a new address/multisig.

