### PR TITLE
Adding Fuel constants to onboard

### DIFF
--- a/contracts/proxy-contract/Cargo.toml
+++ b/contracts/proxy-contract/Cargo.toml
@@ -7,8 +7,9 @@ license = "Apache-2.0"
 
 [dependencies]
 fuels = { workspace = true }
-tokio = { workspace = true }
 test-utils = { workspace = true }
+tokio = { workspace = true }
+
 # Not the latest version because of indexer bug o.o 
 
 [[test]]

--- a/deploy-scripts/Cargo.toml
+++ b/deploy-scripts/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
+csv = { workspace = true }
 dotenv = { workspace = true }
 fuels = { workspace = true }
 futures = { workspace = true }
@@ -13,10 +14,10 @@ hex = { workspace = true }
 pbr = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+tai64 = { workspace = true }
 test-utils = { workspace = true }
 tokio = { workspace = true }
-csv = { workspace = true }
-tai64 = { workspace = true }
+
 
 [lib]
 doctest = false

--- a/deploy-scripts/src/add_asset.rs
+++ b/deploy-scripts/src/add_asset.rs
@@ -23,6 +23,7 @@ pub async fn add_asset(symbol: &str) {
     // Get asset constants based on symbol and network type
     let asset_constants = match (symbol.to_uppercase().as_str(), is_testnet) {
         // Testnet
+        ("FUEL", true) => &constants::TESTNET_FUEL_CONSTANTS,
         ("ETH", true) => &constants::TESTNET_ETH_CONSTANTS,
         ("WSTETH", true) => &constants::TESTNET_WSTETH_CONSTANTS,
         ("EZETH", true) => &constants::TESTNET_EZETH_CONSTANTS,
@@ -30,6 +31,7 @@ pub async fn add_asset(symbol: &str) {
         ("RSETH", true) => &constants::TESTNET_RSETH_CONSTANTS,
         ("METH", true) => &constants::TESTNET_METH_CONSTANTS,
         // Mainnet
+        ("FUEL", false) => &constants::MAINNET_FUEL_CONSTANTS,
         ("ETH", false) => &constants::MAINNET_ETH_CONSTANTS,
         ("WSTETH", false) => &constants::MAINNET_WSTETH_CONSTANTS,
         ("EZETH", false) => &constants::MAINNET_EZETH_CONSTANTS,

--- a/deploy-scripts/src/constants.rs
+++ b/deploy-scripts/src/constants.rs
@@ -49,6 +49,9 @@ pub const MAINNET_RSETH_DECIMALS: u32 = 9;
 pub const MAINNET_METH_ASSET_ID: &str =
     "0xafd219f513317b1750783c6581f55530d6cf189a5863fd18bd1b3ffcec1714b4";
 pub const MAINNET_METH_DECIMALS: u32 = 9;
+pub const MAINNET_FUEL_ASSET_ID: &str =
+    "0x1d5d97005e41cae2187a895fd8eab0506111e0e2f3331cd3912c15c24e3c1d82";
+pub const MAINNET_FUEL_DECIMALS: u32 = 9;
 
 // pyth price ids
 // https://www.pyth.network/developers/price-feed-ids#pyth-evm-stable
@@ -64,6 +67,8 @@ pub const PYTH_RSETH_PRICE_ID: &str =
     "0caec284d34d836ca325cf7b3256c078c597bc052fbd3c0283d52b581d68d71f";
 pub const PYTH_METH_PRICE_ID: &str =
     "fbc9c3a716650b6e24ab22ab85b1c0ef4141b18f4590cc0b986e2f9064cf73d6";
+pub const PYTH_FUEL_PRICE_ID: &str =
+    "8a757d54e5d34c7ff1aea8502a2d968686027a304d00418092aaf7e60ed98d95";
 pub const PYTH_PZETH_PRICE_ID: &str = ""; // Waiting for Pyth price feed
 
 pub struct AssetConstants {
@@ -76,6 +81,16 @@ pub struct AssetConstants {
 }
 
 // Asset-specific constants
+
+pub const TESTNET_FUEL_CONSTANTS: AssetConstants = AssetConstants {
+    symbol: "FUEL",
+    asset_contract_id: None,
+    asset_id: None,
+    pyth_contract_id: TESTNET_PYTH_CONTRACT_ID,
+    pyth_price_id: PYTH_FUEL_PRICE_ID,
+    decimals: 9,
+};
+
 pub const TESTNET_ETH_CONSTANTS: AssetConstants = AssetConstants {
     symbol: "ETH",
     asset_contract_id: None,
@@ -131,6 +146,16 @@ pub const TESTNET_METH_CONSTANTS: AssetConstants = AssetConstants {
 };
 
 // Mainnet
+
+pub const MAINNET_FUEL_CONSTANTS: AssetConstants = AssetConstants {
+    symbol: "FUEL",
+    asset_contract_id: Some(MAINNET_ASSET_CONTRACT_ID),
+    asset_id: Some(MAINNET_FUEL_ASSET_ID),
+    pyth_contract_id: MAINNET_PYTH_CONTRACT_ID,
+    pyth_price_id: PYTH_FUEL_PRICE_ID,
+    decimals: MAINNET_FUEL_DECIMALS,
+};
+
 pub const MAINNET_ETH_CONSTANTS: AssetConstants = AssetConstants {
     symbol: "ETH",
     asset_contract_id: Some(MAINNET_ASSET_CONTRACT_ID),


### PR DESCRIPTION
# Add FUEL token constants

Added FUEL token constants to support FUEL token integration. This includes:
- FUEL asset ID and decimals for mainnet
- FUEL Pyth price feed ID
- Asset constants structs for both testnet and mainnet environments